### PR TITLE
Support svg show directly, disable html show

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -18,13 +18,16 @@ end
 Returns an SVG representation of the given plot as a string.
 """
 function to_svg(plot::PenPlot)
+    repr(MIME"image/svg+xml"(), plot)
+end
+
+Base.show(io::IO, ::MIME"image/svg+xml", plot::PenPlot)
     ext = extent(plot)
     width = ext.lowerright[1] - ext.upperleft[1]
     height = ext.lowerright[2] - ext.upperleft[2]
 
-    builder = IOBuffer()
     print(
-        builder,
+        io,
         """<svg
 xmlns="http://www.w3.org/2000/svg"
 height="400"
@@ -34,7 +37,7 @@ viewBox="$(ext.upperleft[1]) $(ext.upperleft[2]) $(width) $(height)">""",
 
     for layer in plot.layers
         print(
-            builder,
+            io,
             """<g id="$(layer.name)"
 stroke="#$(hex(layer.color))"
 opacity="0.5"
@@ -43,7 +46,7 @@ fill="none">""",
 
         for path in layer.paths
             print(
-                builder,
+                io,
                 """<path
   d="$(to_path_string(path))"
   vector-effect="non-scaling-stroke"
@@ -51,34 +54,18 @@ fill="none">""",
             )
         end
 
-        print(builder, "</g>")
+        print(io, "</g>")
     end
 
-    print(builder, "</svg>")
-
-    String(take!(builder))
+    print(io, "</svg>")
 end
 
-function Base.show(io::IO, mime::MIME"text/html", path::Path)
+function Base.show(io::IO, mime::MIME"image/svg+xml", path::Path)
     plot = PenPlot([path])
     Base.show(io, mime, plot)
 end
 
-function Base.show(io::IO, mime::MIME"text/html", paths::MultiPath)
+function Base.show(io::IO, mime::MIME"image/svg+xml", paths::MultiPath)
     plot = PenPlot(paths)
     Base.show(io, mime, plot)
-end
-
-function Base.show(io::IO, mime::MIME"text/html", plot::PenPlot)
-    svgdata = to_svg(plot)
-
-    # Write SVG element.
-    write(io, svgdata)
-
-    # Write download button.
-    data_encoded = base64encode(svgdata)
-    url = "data:image/svg+xml;base64,$(data_encoded)"
-    write(io, "<div>")
-    write(io, """<a href="$(url)" download="plot.svg"><button>Download</button></a>""")
-    write(io, "</div>")
 end

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -21,7 +21,7 @@ function to_svg(plot::PenPlot)
     repr(MIME"image/svg+xml"(), plot)
 end
 
-Base.show(io::IO, ::MIME"image/svg+xml", plot::PenPlot)
+function Base.show(io::IO, ::MIME"image/svg+xml", plot::PenPlot)
     ext = extent(plot)
     width = ext.lowerright[1] - ext.upperleft[1]
     height = ext.lowerright[2] - ext.upperleft[2]


### PR DESCRIPTION
As I talked about in my email, by telling Julia how to show a PenPlot as SVG, you tell Pluto that it should display it using an `<img>` tag. SVG as data to an `<img>` tag can be right-click-saved.

Jupyter & VS Code will still work, they both support the SVG MIME type.

I kept `to_svg`, but you could remove it too if it's not used for anything else.

(I did not test this code, but hopefully it works already!)